### PR TITLE
fix: replace safelist with `lib` path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 .next
+
+# misc
+.DS_Store

--- a/app/chart.tsx
+++ b/app/chart.tsx
@@ -18,12 +18,6 @@ export function Chart({
         `$${Intl.NumberFormat("us").format(number).toString()}`
       }
       colors={
-        /* noteworthy: for this color to work, since it's not referenced
-         * directly in the code as a `className` and signal to the
-         * Tailwind compiler that it's used and to be included in the
-         * "pruned" css, we defined `stroke-amber - 500` and `bg - amber - 500`
-         * in the `safelist` prop of `tawildinw.config.js`
-         * https://sdk.vercel.ai/s/mjiuFU7cQtRN */
         ["amber"]
       }
       xAxisLabel="Month"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,8 +5,8 @@ const config: Config = {
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./lib/**/*.{js,ts,jsx,tsx,mdx}",
   ],
-  safelist: ["stroke-amber-500", "bg-amber-500"],
   theme: {
     extend: {
       keyframes: {


### PR DESCRIPTION
Hi!

This PR removes the safelisted colors in `tailwind.config.ts`. Instead, we add the path of the `lib` folder to the content section.

This ensures that all defined colors in `chart-utils.tsx` are generated.

```diff
  "./pages/**/*.{js,ts,jsx,tsx,mdx}",
    "./components/**/*.{js,ts,jsx,tsx,mdx}",
    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+   "./lib/**/*.{js,ts,jsx,tsx,mdx}",
  ],
- safelist: ["stroke-amber-500", "bg-amber-500"],
  theme: {
    extend: {
      keyframes: {
```